### PR TITLE
fix: fix the voting team and threshold

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -61,7 +61,7 @@ profiles:
     #
     # The percentage is calculated based on the number of votes in favor and the
     # number of allowed voters (see allowed_voters field below for more details).
-    pass_threshold: 50
+    pass_threshold: 66
 
     # Allowed voters (optional)
     #
@@ -84,7 +84,8 @@ profiles:
     #     - tegioz
     #
     allowed_voters:
-      teams: []
+      teams:
+        - ratify-org-maintainers
       users: []
 
   # Additional configuration profiles


### PR DESCRIPTION
Update the default voting profile to select org maintainers to vote with 2/3 pass threshold.